### PR TITLE
[YOSHINO] Fix dynamic memory bus latency parameters

### DIFF
--- a/rootdir/init.yoshino.pwr.rc
+++ b/rootdir/init.yoshino.pwr.rc
@@ -181,9 +181,11 @@ on boot
 
     # Enable dynamic memory bus latency control
     write /sys/class/devfreq/soc:qcom,memlat-cpu0/governor "mem_latency"
-    write /sys/class/devfreq/soc:qcom,memlat-cpu0/polling_interval 50
+    write /sys/class/devfreq/soc:qcom,memlat-cpu0/polling_interval 10
+    write /sys/class/devfreq/soc:qcom,memlat-cpu0/mem_latency/ratio_ceil 400
     write /sys/class/devfreq/soc:qcom,memlat-cpu4/governor "mem_latency"
-    write /sys/class/devfreq/soc:qcom,memlat-cpu4/polling_interval 50
+    write /sys/class/devfreq/soc:qcom,memlat-cpu4/polling_interval 10
+    write /sys/class/devfreq/soc:qcom,memlat-cpu4/mem_latency/ratio_ceil 400
 
     write /sys/class/devfreq/soc:qcom,mincpubw/governor "cpufreq"
 


### PR DESCRIPTION
We had MSM8996 parameters in there and.. for 8998
we need different params.