### PR TITLE
[YOSHINO] Add custom ACDB IDs mapping for OSS audio HALs

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -37,6 +37,21 @@
         <device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK_MONO_2" acdb_id="152"/>
         <device name="SND_DEVICE_OUT_SONY_VOICE_SPEAKER" acdb_id="150"/>
         <device name="SND_DEVICE_OUT_SONY_VOICE_TTY_HCO_SPEAKER" acdb_id="150"/>
+
+	<!-- Custom mapping starts here -->
+        <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="-1"/>
+        <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
+        <device name="SND_DEVICE_OUT_VOICE_HEADPHONES" acdb_id="10"/>
+
+        <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="6"/>
+	<device name="SND_DEVICE_IN_HANDSET_DMIC" acdb_id="4"/>
+        <device name="SND_DEVICE_IN_HEADSET_MIC" acdb_id="528"/>
+        <device name="SND_DEVICE_IN_HEADSET_MIC_ASR" acdb_id="529"/>
+        <device name="SND_DEVICE_IN_VOICE_HEADSET_MIC" acdb_id="8"/>
+        <device name="SND_DEVICE_IN_VOICE_REC_MIC" acdb_id="-1"/>
+	<device name="SND_DEVICE_IN_VOICE_DMIC" acdb_id="4" />
+        <device name="SND_DEVICE_IN_CAPTURE_VI_FEEDBACK" acdb_id="102"/>
+	<!-- Custom mapping ends here -->
     </acdb_ids>
     <bit_width_configs>
         <device name="SND_DEVICE_OUT_SPEAKER" bit_width="24"/>


### PR DESCRIPTION
This is necessary because Sony's stock HALs have these mappings
hardcoded, while open source HALs have generic QCOM mappings.
This includes both CAF and AOSP versions.