### PR TITLE
[YOSHINO] ueventd: Add permissions to fb0 node for Dynamic Resolution Switch

### DIFF
--- a/rootdir/ueventd.yoshino.rc
+++ b/rootdir/ueventd.yoshino.rc
@@ -170,6 +170,9 @@
 /sys/devices/soc/soc:fpc1145 irq              0660 system input
 /sys/devices/soc/soc:fpc1145 wakeup_enable    0220 system input
 
+# Framebuffer for Dynamic Resolution Switch
+/sys/devices/virtual/graphics/fb0/mode        0664 system graphics
+
 # Thermanager
 /sys/module/msm_performance/parameters/cpu_max_freq   0664 system system
 /sys/module/msm_performance/parameters/cpu_min_freq   0664 system system


### PR DESCRIPTION
This is needed for DRS to work.