### PR TITLE
[master] sony: yoshino: Increase max number of compression streams

### DIFF
--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -16,6 +16,9 @@ import init.common.rc
 import init.common.usb.rc
 import init.yoshino.pwr.rc
 
+on init
+    write /sys/block/zram0/max_comp_streams 8
+
 on fs
     symlink /dev/block/platform/soc/1da4000.ufshc /dev/block/bootdevice
 


### PR DESCRIPTION
Regardless the value passed to this attribute, ZRAM will always
allocate multiple compression streams - one per online CPUs - thus
allowing several concurrent compression operations. The number of
allocated compression streams goes down when some of the CPUs
become offline. There is no single-compression-stream mode anymore,
unless you are running a UP system or has only 1 CPU online.

Change-Id: I8997d92265308c962e0ac9b4119be567c4898988
Signed-off-by: Humberto Borba <humberos@gmail.com>