### PR TITLE
yoshino: remove not needed fingerprint service

### DIFF
--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -139,13 +139,6 @@ service per_proxy /system/vendor/bin/pm-proxy
     disabled
     writepid /dev/cpuset/system-background/tasks
 
-# Fingerprint service
-service fingerprintd /system/bin/fingerprintd
-    class late_start
-    user system
-    group input
-    writepid /dev/cpuset/system-background/tasks
-
 service msm_irqbalance /system/vendor/bin/msm_irqbalance -f /system/etc/msm_irqbalance.conf
     socket msm_irqbalance seqpacket 660 root system
     class core


### PR DESCRIPTION
daemon fingerprint is not more on android oreo it was replaced by android.hardware.biometrics.fingerprint

Signed-off-by: David Viteri <davidteri91@gmail.com>