### PR TITLE
yoshino: fix init power paths

### DIFF
--- a/rootdir/init.yoshino.pwr.rc
+++ b/rootdir/init.yoshino.pwr.rc
@@ -147,16 +147,12 @@ on boot
     write /proc/sys/kernel/sched_freq_dec_notify 50000
 
     # disallow upmigrate for cgroup's tasks
-    write /dev/cpuctl/bg_non_interactive/cpu.upmigrate_discourage 1
+    write /dev/cpuctl/cpu.upmigrate_discourage 1
 
     #enable sched colocation and colocation inheritance
     write /proc/sys/kernel/sched_upmigrate 130
     write /proc/sys/kernel/sched_downmigrate 110
     write /proc/sys/kernel/sched_enable_thread_grouping 1
-
-    chown system system /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
-    chown system system /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
-    chown system system /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 
     # set cpu_boost parameters
     write /sys/module/cpu_boost/parameters/input_boost_freq "0:1324800"


### PR DESCRIPTION
maple:/dev/cpuctl # ls
cgroup.clone_children  cgroup.sane_behavior  cpu.rt_runtime_us  cpu.upmigrate_discourage  release_agent
cgroup.procs           cpu.rt_period_us      cpu.shares         notify_on_release         tasks

also remove not existent ondemand governor paths

Signed-off-by: David Viteri <davidteri91@gmail.com>