### PR TITLE
yoshino: set headphones acdb_id map

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -39,7 +39,7 @@
         <device name="SND_DEVICE_OUT_SONY_VOICE_TTY_HCO_SPEAKER" acdb_id="150"/>
 
         <!-- Custom mapping starts here -->
-        <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="-1"/>
+        <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="10"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
         <device name="SND_DEVICE_OUT_VOICE_HEADPHONES" acdb_id="10"/>
 


### PR DESCRIPTION
needed by maple to run audio on stereo mode after commit 992aa870ca89f08214d3aef5490e1e67d36e2a0d

Signed-off-by: David Viteri <davidteri91@gmail.com>