### PR TITLE
yoshino: fix cpuset

### DIFF
--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -76,6 +76,7 @@ on boot
     chmod 0660 /sys/devices/soc/fpc1145_device/irq
 
     # add a cpuset for the camera daemon
+    # we want all the little cores for camera
     mkdir /dev/cpuset/camera-daemon
     write /dev/cpuset/camera-daemon/cpus 0
     write /dev/cpuset/camera-daemon/mems 0
@@ -84,9 +85,9 @@ on boot
     chmod 0664 /dev/cpuset/camera-daemon/tasks
 
     # update foreground cpuset now that processors are up
-    write /dev/cpuset/foreground/cpus 0-8
-    write /dev/cpuset/foreground/boost/cpus 0-8
-    write /dev/cpuset/background/cpus 0-1
+    write /dev/cpuset/foreground/cpus 0-7
+    write /dev/cpuset/foreground/boost/cpus 0-7
+    write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-1
 
 # OSS WLAN and BT MAC setup


### PR DESCRIPTION
correct soc range for octa core is 0-7 not 0-8
preserve core 3 little core for camera

Signed-off-by: David Viteri <davidteri91@gmail.com>