### PR TITLE
yoshino: fix leds

### DIFF
--- a/rootdir/ueventd.yoshino.rc
+++ b/rootdir/ueventd.yoshino.rc
@@ -20,9 +20,6 @@
 #permissions for CSVT
 /dev/smd11                0660   radio      radio
 
-#permsissions for BT/FM
-/dev/btpower              0660   bluetooth  system
-
 #permissions for pta
 /dev/pta                  0660   system     system
 
@@ -157,12 +154,12 @@
 
 # LED
 /sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds/led:* max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds/led:* brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300/leds/led:* max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300/leds/led:* brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300/leds/led:* blink 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d800/leds/wled max_brightness 0664 system system
-/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d800/leds/wled brightness 0664 system system
+/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds/led:* brightness     0664 system system
+/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds/led:* blink          0664 system system
+/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d800/leds/wled  max_brightness 0664 system system
+/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d800/leds/wled  brightness     0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                                                                                 0644 root system
+/sys/class/leds/lcd-backlight/brightness                                                                                     0664 system system
 
 # Fingerprint sensor  device
 /sys/devices/soc/soc:fpc1145 hw_reset         0220 system input


### PR DESCRIPTION
maple:/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds # ls
led:rgb_blue  led:rgb_green  led:rgb_red

(led:rgb_blue led:rgb_green led:rgb_red) needs blink permissions

maple:/sys/devices/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300/leds # ls
led:flash_0  led:flash_1  led:switch_0  led:torch_0  led:torch_1

remove (led:flash_0 led:flash_1 led:switch_0 led:torch_0 led:torch_1) paths

add lcd-backlight permissions

also remove double /dev/btpower path and perms

Signed-off-by: David Viteri <davidteri91@gmail.com>