### PR TITLE
yoshino: set correct acdb_id for speaker case

### DIFF
--- a/rootdir/system/etc/audio_platform_info.xml
+++ b/rootdir/system/etc/audio_platform_info.xml
@@ -26,10 +26,11 @@
 <!-- IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                          -->
 <audio_platform_info>
     <acdb_ids>
-        <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="15"/>
+        <!--<device name="SND_DEVICE_OUT_SPEAKER" acdb_id="15"/>-->
         <device name="SND_DEVICE_OUT_SPEAKER_PROTECTED" acdb_id="124"/>
         <device name="SND_DEVICE_IN_VOICE_REC_DMIC_FLUENCE" acdb_id="132"/>
         <!-- Custom mapping starts here -->
+        <device name="SND_DEVICE_OUT_SPEAKER" acdb_id="124"/>
         <device name="SND_DEVICE_OUT_HEADPHONES" acdb_id="10"/>
         <device name="SND_DEVICE_OUT_VOICE_HANDSET" acdb_id="7"/>
         <device name="SND_DEVICE_OUT_VOICE_HEADPHONES" acdb_id="10"/>


### PR DESCRIPTION
values picked from lilac stock

09-21 15:09:02.705   901  4905 D audio_hw_utils: audio_extn_utils_send_app_type_cfg: usecase->out_snd_device speaker
09-21 15:09:02.705   901  4905 I audio_hw_utils: send_app_type_cfg_for_device PLAYBACK app_type 69937, acdb_dev_id 124, sample_rate 48000, snd_device_be_idx 2
09-21 15:09:02.706   901  4905 D ACDB-LOADER: ACDB -> send_audio_cal, acdb_id = 124, path = 0, app id = 0x11131, sample rate = 48000

Signed-off-by: David Viteri <davidteri91@gmail.com>