### PR TITLE
yoshino: Use standard ifeq in Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-ifeq ($(filter-out yoshino,$(PRODUCT_PLATFORM)),)
+ifeq (yoshino,$(PRODUCT_PLATFORM))
 
 LOCAL_PATH := $(call my-dir)
 


### PR DESCRIPTION
The filter-out version was not null proof.
In case of PRODUCT_PLATFORM being unset (for example when building a non sony device with Sony trees local) the filter-out condition was falsely turning true and called all sub-makefiles, which is obviously nothing we want.