### PR TITLE
yoshino: remove duplicated entries

### DIFF
--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -58,11 +58,6 @@ on boot
     # Allow access for CCID command/response timeout configuration
     chown system system /sys/module/ccid_bridge/parameters/bulk_msg_timeout
 
-    # Mark the copy complete flag to not completed
-    write /data/misc/radio/copy_complete 0
-    chown radio radio /data/misc/radio/copy_complete
-    chmod 0660 /data/misc/radio/copy_complete
-
     # Socket location for RIDL
     mkdir /dev/socket/RIDL 2770 system system
 


### PR DESCRIPTION
already defined in common

see: https://github.com/sonyxperiadev/device-sony-common/blob/master/rootdir/init.common.rc#L168

Signed-off-by: David Viteri <davidteri91@gmail.com>