### PR TITLE
yoshino: clean ramdump partition for userdebug and eng variants

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -78,6 +78,9 @@ TARGET_PER_MGR_ENABLED := true
 
 # SELinux
 BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform-userdebug
+endif
 
 # Display
 NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3

--- a/platform.mk
+++ b/platform.mk
@@ -65,7 +65,8 @@ DEVICE_PACKAGE_OVERLAYS += \
 # Platform Init
 PRODUCT_PACKAGES += \
     fstab.yoshino \
-    init.yoshino.pwr
+    init.yoshino.pwr \
+    rdclean.sh
 
 # Audio
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -18,6 +18,10 @@ LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
 include $(BUILD_PREBUILT)
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+$(LOCAL_BUILT_MODULE):
+	$(hide) sed -e "s,^\(.*mount_all.*\)$$,\1\n    exec_start rdclean," $^ > $@
+endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.yoshino.pwr
@@ -38,6 +42,17 @@ LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT)
 include $(BUILD_PREBUILT)
+
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+include $(CLEAR_VARS)
+LOCAL_MODULE             := rdclean.sh
+LOCAL_MODULE_CLASS       := EXECUTABLES
+LOCAL_SRC_FILES_arm64    := vendor/bin/rdclean.sh
+LOCAL_INIT_RC_64         := vendor/etc/init/rdclean.rc
+LOCAL_MODULE_TARGET_ARCH := arm64
+LOCAL_VENDOR_MODULE      := true
+include $(BUILD_PREBUILT)
+endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := ueventd.$(TARGET_DEVICE)

--- a/rootdir/vendor/bin/rdclean.sh
+++ b/rootdir/vendor/bin/rdclean.sh
@@ -1,0 +1,8 @@
+#!/system/bin/sh
+
+dev=/dev/block/bootdevice/by-name/rdimage
+
+[ "`dd if=$dev bs=1 count=8 2>/dev/null`" = "ANDROID!" ] && {
+	log -p w -t rdclean clearing ramdump partition
+	cat /dev/zero > $dev
+}

--- a/rootdir/vendor/etc/init/rdclean.rc
+++ b/rootdir/vendor/etc/init/rdclean.rc
@@ -1,0 +1,4 @@
+service rdclean /vendor/bin/rdclean.sh
+    user root
+    disabled
+    oneshot

--- a/sepolicy_platform-userdebug/device.te
+++ b/sepolicy_platform-userdebug/device.te
@@ -1,0 +1,1 @@
+type rdimage_block_device, dev_type;

--- a/sepolicy_platform-userdebug/file_contexts
+++ b/sepolicy_platform-userdebug/file_contexts
@@ -1,0 +1,10 @@
+##########################
+# Devices
+#
+/dev/block/platform/soc/1da4000\.ufshc/by-name/rdimage         u:object_r:rdimage_block_device:s0
+/dev/block/bootdevice/by-name/rdimage                          u:object_r:rdimage_block_device:s0
+
+#############################
+# System files
+#
+/(vendor|system/vendor)/bin/rdclean.sh                         u:object_r:rdclean_exec:s0

--- a/sepolicy_platform-userdebug/rdclean.te
+++ b/sepolicy_platform-userdebug/rdclean.te
@@ -1,0 +1,7 @@
+type rdclean, domain;
+type rdclean_exec, exec_type, file_type;
+
+init_daemon_domain(rdclean);
+
+allow rdclean rdimage_block_device:blk_file rw_file_perms;
+allow rdclean { shell_exec toolbox_exec }:file rx_file_perms;


### PR DESCRIPTION
This is to make sure ramdumper won't be invoked for the userdebug and
engineering variants. Service is started from init.$(TARGET_DEVICE).rc
right after the mount_all, check the $OUT/root/. There must be no
traces of this tool in the user variant.

NOTE: current version is for the system/vendor/ and has to be revised
      once vendor image is enabled

Signed-off-by: Oleksiy Avramchenko <oleksiy.avramchenko@sony.com>