### PR TITLE
yoshino: add sys.usb.rndis.func.name prop

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -146,4 +146,5 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # USB controller setup
 PRODUCT_PROPERTY_OVERRIDES += \
-    sys.usb.controller=a800000.dwc3
+    sys.usb.controller=a800000.dwc3 \
+    sys.usb.rndis.func.name=gsi


### PR DESCRIPTION
needed for USB tethering usecase

Signed-off-by: David Viteri <davidteri91@gmail.com>