### PR TITLE
Revert "Revert "yoshino: enable 60fps for 1080p and 720p video record…

### DIFF
--- a/rootdir/system/etc/media_profiles_V1_0.xml
+++ b/rootdir/system/etc/media_profiles_V1_0.xml
@@ -27,7 +27,7 @@
                    bitRate="17500000"
                    width="1920"
                    height="1080"
-                   frameRate="30" />
+                   frameRate="60" />
             <Audio codec="aac"
                    bitRate="156000"
                    sampleRate="48000"
@@ -39,7 +39,7 @@
                    bitRate="12000000"
                    width="1280"
                    height="720"
-                   frameRate="30" />
+                   frameRate="60" />
             <Audio codec="aac"
                    bitRate="156000"
                    sampleRate="48000"


### PR DESCRIPTION
…ing""

enable only 60fps without touch bitrate to preserve compatibility

This reverts commit 44043d12c207f4c45e7948f2fe08e59b941c388f.