### PR TITLE
Fixes for creating MAC address files on Oreo

### DIFF
--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -89,7 +89,7 @@ on boot
 service macaddrsetup /system/vendor/bin/macaddrsetup /data/misc/wifi/wlan_mac.bin
     class core
     user system
-    group system bluetooth
+    group system bluetooth wifi
     disabled
     oneshot
     writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
In order to write the WLAN MAC address to /data/misc/wifi/wlan_mac.bin, macaddrsetup needs to be in the wifi group.