### PR TITLE
[YOSHINO] ueventd: Fix for FPC IOCTL implementation

### DIFF
--- a/rootdir/ueventd.yoshino.rc
+++ b/rootdir/ueventd.yoshino.rc
@@ -162,12 +162,7 @@
 /sys/class/leds/lcd-backlight/brightness                                                                                     0664 system system
 
 # Fingerprint sensor  device
-/sys/devices/soc/soc:fpc1145 hw_reset         0220 system input
-/sys/devices/soc/soc:fpc1145 pinctl_set       0220 system input
-/sys/devices/soc/soc:fpc1145 regulator_enable 0220 system input
-/sys/devices/soc/soc:fpc1145 spi_prepare      0220 system input
-/sys/devices/soc/soc:fpc1145 irq              0660 system input
-/sys/devices/soc/soc:fpc1145 wakeup_enable    0220 system input
+/dev/fingerprint         0664 system input
 
 # Framebuffer for Dynamic Resolution Switch
 /sys/devices/virtual/graphics/fb0/mode        0664 system graphics


### PR DESCRIPTION
Remove sysfs entries, replace them with the new device at
/dev/fingerprint for the new IOCTL implementation.