### PR TITLE
[MASTER] sepolicy: add oem partition

### DIFF
--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -46,4 +46,7 @@
 /dev/block/platform/soc/1da4000\.ufshc/by-name/rdimage         u:object_r:ramdump_block_device:s0
 /dev/block/bootdevice/by-name/rdimage                          u:object_r:ramdump_block_device:s0
 
+/dev/block/platform/soc/1da4000\.ufshc/by-name/oem             u:object_r:system_block_device:s0
+/dev/block/bootdevice/by-name/oem                              u:object_r:system_block_device:s0
+
 /dev/block/zram0                                               u:object_r:swap_block_device:s0


### PR DESCRIPTION
We use the oem partition to store vendor blobs and we mark the
partition as system_block_device