### PR TITLE
fix camera rotation bug

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -147,3 +147,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     sys.usb.controller=a800000.dwc3 \
     sys.usb.rndis.func.name=gsi
+
+# Camera Rotation
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.camera.lib2d.rotation=on


### PR DESCRIPTION
If the persist.camera.lib2d.rotation property is not set,
the QCamera2PostProc::encodeData() function will not
initialize the rotation value correctly, leading to
wrongly rotated images.