### PR TITLE
[n-mr1] changes for FBE

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -156,3 +156,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Camera Rotation
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.lib2d.rotation=on
+
+# verity
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.verified_boot.xml:system/etc/permissions/android.software.verified_boot.xml
+
+# setup dm-verity configs.
+PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/1da4000.ufshc/by-name/system
+$(call inherit-product, build/target/product/verity.mk)

--- a/platform.mk
+++ b/platform.mk
@@ -43,6 +43,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/usr/keylayout/gpio-keys.kl:system/usr/keylayout/gpio-keys.kl
 
+# FBE support
+PRODUCT_COPY_FILES += \
+    $(SONY_ROOT)/system/bin/init.qti.qseecomd.sh:system/bin/init.qti.qseecomd.sh
+
 # MSM IRQ Balancer configuration file
 PRODUCT_COPY_FILES += \
     $(SONY_ROOT)/system/etc/msm_irqbalance.conf:system/etc/msm_irqbalance.conf

--- a/rootdir/fstab.yoshino
+++ b/rootdir/fstab.yoshino
@@ -5,7 +5,7 @@
 /dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,verify=/dev/block/bootdevice/by-name/fsmetadata
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,discard,errors=panic latemount,wait,check,formattable,fileencryption=ice
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/fstab.yoshino
+++ b/rootdir/fstab.yoshino
@@ -2,7 +2,7 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,verify=/dev/block/bootdevice/by-name/fsmetadata
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer

--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -18,6 +18,9 @@ import init.common.usb.rc
 import init.yoshino.pwr.rc
 
 on init
+    # Load persistent dm-verity state
+    verity_load_state
+
     write /sys/block/zram0/max_comp_streams 8
 
 on fs
@@ -34,6 +37,10 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
     write /sys/kernel/boot_slpi/boot 1
     write /dev/ipa 1
+
+on early-boot
+    # Update dm-verity state and set partition.*.verified properties
+    verity_update_state
 
 on boot
     # WLAN MAC

--- a/rootdir/init.yoshino.rc
+++ b/rootdir/init.yoshino.rc
@@ -24,8 +24,8 @@ on init
     write /sys/block/zram0/max_comp_streams 8
 
 on fs
-    mount_all ./fstab.yoshino
-    swapon_all ./fstab.yoshino
+    mount_all fstab.yoshino --early
+    swapon_all fstab.yoshino
 
     # /dsp is initially unlabelled so we need to mount
     # it as rw, restore AOSP labels, then remount
@@ -37,6 +37,13 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
     write /sys/kernel/boot_slpi/boot 1
     write /dev/ipa 1
+
+on late-fs
+
+    start qseecomd
+    exec - root root root -- /system/bin/init.qti.qseecomd.sh
+
+    mount_all fstab.yoshino --late
 
 on early-boot
     # Update dm-verity state and set partition.*.verified properties

--- a/rootdir/system/bin/init.qti.qseecomd.sh
+++ b/rootdir/system/bin/init.qti.qseecomd.sh
@@ -1,0 +1,35 @@
+#!/system/bin/sh
+# Copyright (c) 2016, The Linux Foundation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of The Linux Foundation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+while [ "$registered" != "true" ]
+do
+    sleep 0.1
+    registered="`getprop sys.listeners.registered`"
+done

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -50,3 +50,7 @@
 /dev/block/bootdevice/by-name/oem                              u:object_r:system_block_device:s0
 
 /dev/block/zram0                                               u:object_r:swap_block_device:s0
+
+##################################
+# FBE
+/system/bin/init.qti.qseecomd.sh                               u:object_r:init-qti-fbe-sh_exec:s0

--- a/sepolicy_platform/file_contexts
+++ b/sepolicy_platform/file_contexts
@@ -16,6 +16,9 @@
 /dev/block/platform/soc/1da4000\.ufshc/by-name/fsc             u:object_r:modem_block_device:s0
 /dev/block/bootdevice/by-name/fsc                              u:object_r:modem_block_device:s0
 
+/dev/block/platform/soc/1da4000\.ufshc/by-name/fsmetadata      u:object_r:metadata_block_device:s0
+/dev/block/bootdevice/by-name/fsmetadata                       u:object_r:metadata_block_device:s0
+
 /dev/block/platform/soc/1da4000\.ufshc/by-name/ssd             u:object_r:ssd_block_device:s0
 /dev/block/bootdevice/by-name/ssd                              u:object_r:ssd_block_device:s0
 

--- a/sepolicy_platform/init-qti-fbe-sh.te
+++ b/sepolicy_platform/init-qti-fbe-sh.te
@@ -1,0 +1,38 @@
+# Copyright (c) 2016, The Linux Foundation. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of The Linux Foundation nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+type init-qti-fbe-sh, domain;
+type init-qti-fbe-sh_exec, exec_type, file_type;
+
+init_daemon_domain(init-qti-fbe-sh)
+
+get_prop(init-qti-fbe-sh, tee_prop)
+
+allow init-qti-fbe-sh shell_exec:file rx_file_perms;
+
+# execute toybox/toolbox
+allow init-qti-fbe-sh toolbox_exec:file rx_file_perms;


### PR DESCRIPTION
adapt the following two upstream commits:
```
  remote: https://source.codeaurora.org/quic/la/device/qcom/sepolicy
  branch: sepolicy.lnx.2.0.r15-rel

  edbf13e sepolicy: added policy fixes for FBE to work properly
  2352ad5 sepolicy: Rename qseecomd policy rules for msm8998
```