### PR TITLE
[master] Remove kernel and mkbootimg flags

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -41,13 +41,6 @@ BOARD_KERNEL_CMDLINE += androidboot.bootdevice=1da4000.ufshc
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += display_status=on
 
-BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
-
-TARGET_KERNEL_ARCH := arm64
-TARGET_KERNEL_HEADER_ARCH := arm64
-TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
-BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
-
 TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/fstab.yoshino
 
 TARGET_PD_SERVICE_ENABLED := true


### PR DESCRIPTION
These flags are common for all current platforms and
have been moved to the common repository.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>