### PR TITLE
yoshino: remove double audio props

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -99,9 +99,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Fluence
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.qc.sdk.audio.fluencetype=fluence \
-    persist.audio.fluence.voicecall=true \
-    persist.audio.fluence.speaker=true
+    ro.qc.sdk.audio.fluencetype=fluence
 
 # aDSP sensors
 ## max rate


### PR DESCRIPTION
those are already defined at common

Signed-off-by: David Viteri <davidteri91@gmail.com>