### PR TITLE
[o-mr0] fix generation of OTA packages

### DIFF
--- a/rootdir/fstab.yoshino
+++ b/rootdir/fstab.yoshino
@@ -2,6 +2,8 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults

--- a/rootdir/fstab.yoshino
+++ b/rootdir/fstab.yoshino
@@ -2,8 +2,8 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait
-/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
 /dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,discard,errors=panic wait,check,formattable,encryptable=footer
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults


### PR DESCRIPTION
After the removal of the mount for system, the build system failed to generate OTA packages, as it relies on fstab to know what to mount when executing the update script.
This reverts the removal of the lines, and adds to them the flag "recoveryonly" to avoid having Android attempt a remount of those partitions.