### PR TITLE
Allow wifi service to access wlan dev node

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -1,5 +1,5 @@
 /dev/genlock              0666   system     system
-/dev/wlan                 0660   system     system
+/dev/wlan                 0660   wifi       wifi
 /dev/kgsl-3d0             0666   system     system
 /dev/ion                  0664   system     system
 /dev/rtc0                 0660   system     system


### PR DESCRIPTION
android.hardware.wifi@1.0-service which is triggered
at boot up time is failing to access the /dev/wlan node.
Modify the uid and gid as wifi to enable the wifi service
to access this node

CRs-Fixed: 2062348
Change-Id: Id649979e762cfbf8801f707500229fec24974a55