### PR TITLE
[YOSHINO] vendor: IDC: clearpad: Fix touch pressure issues and cleanup

### DIFF
--- a/rootdir/vendor/usr/idc/clearpad.idc
+++ b/rootdir/vendor/usr/idc/clearpad.idc
@@ -1,5 +1,14 @@
+# This is an internal device, not an external peripheral attached to the USB
+# or Bluetooth bus.
+device.internal = 1
+
 # Device Type
 touch.deviceType = touchScreen
 
+# Touch positions reported by the touch device are rotated
+# whenever the display orientation changes
+touch.orientationAware = 1
+
 # Pressure
-touch.pressure.scale = 0.0090
+touch.pressure.calibration = physical
+touch.pressure.scale = 0.01


### PR DESCRIPTION
Changes introduced in Android 8.1.0 produced a miscalculation
of the touch pressure axis.
Change the touch pressure scale to 0.01 to prevent overflowing
and get back the touch pressure working properly, solving issues
with multi-touch gestures in various games.

Also, while at it, make sure that the device is declared as internal,
orientation aware and that the touch pressure parameter is read
from the "pressure axis" sent by the kernel driver.