### PR TITLE
[YOSHINO] PlatformConfig: Define TARGET_USES_GRALLOC1 for legacy

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -78,5 +78,6 @@ BOARD_SEPOLICY_DIRS += $(PLATFORM_COMMON_PATH)/sepolicy_platform
 
 # Display
 TARGET_HAS_HDR_DISPLAY := true
+TARGET_USES_GRALLOC1 := true
 
 include device/sony/common/CommonConfig.mk


### PR DESCRIPTION
This platform uses old Adreno binaries and is not compatible
with the new style gralloc.