### PR TITLE
[YOSHINO] wifi: wpa_supplicant_overlay: Declare wowlan support

### DIFF
--- a/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
+++ b/rootdir/vendor/etc/wifi/wpa_supplicant_overlay.conf
@@ -1,3 +1,5 @@
 disable_scan_offload=1
 p2p_disabled=1
 sched_scan_plans=120:2 240
+tdls_external_control=1
+wowlan_triggers=magic_pkt


### PR DESCRIPTION
Enable TDLS mode: external programs are given the control
to specify the TDLS link to get established to the driver.

Specify WoWLAN triggers to permit to keep the WiFi connected
while AP sleeps and the WLAN chip is in low power mode.
Resume the AP to handle special requests via a magic packet
sent from the WLAN chip.