### PR TITLE
label 18800000.qcom,icnss/net as sysfs_net

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -18,6 +18,8 @@ genfscon sysfs /devices/platform/soc/ca1c000.qcom,jpeg                          
 genfscon sysfs /devices/platform/soc/caa0000.qcom,jpeg                           u:object_r:sysfs_camera:s0
 genfscon sysfs /devices/platform/soc/8c0000.qcom,msm-cam                         u:object_r:sysfs_camera:s0
 
+genfscon sysfs /devices/platform/soc/18800000.qcom,icnss/net                     u:object_r:sysfs_net:s0
+
 genfscon sysfs /devices/platform/soc/1da4000.ufshc/clkscale_enable               u:object_r:sysfs_clkscale:s0
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp/caps                  u:object_r:sysfs_mdss_mdp_caps:s0
 genfscon sysfs /devices/platform/soc/a1800000.qcom,rmtfs_rtel_sharedmem          u:object_r:sysfs_rmtfs:s0


### PR DESCRIPTION
following crosshatch and aosp sepolicy
https://android.googlesource.com/device/google/crosshatch-sepolicy/+/android-9.0.0_r21/vendor/qcom/common/genfs_contexts#69
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/public/file.te#82
https://android.googlesource.com/platform/system/sepolicy/+/android-9.0.0_r21/private/priv_app.te#90

avoid
12-12 20:03:11.079  4235  4235 I IntentService[D: type=1400 audit(0.0:101): avc: denied { open } for path=/sys/devices/platform/soc/18800000.qcom,icnss/net/p2p0/type dev=sysfs ino=63502 scontext=u:r:priv_app:s0:c512,c768 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>