### PR TITLE
sepolicy_platform: Remove clkscale label

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -20,7 +20,6 @@ genfscon sysfs /devices/platform/soc/8c0000.qcom,msm-cam                        
 
 genfscon sysfs /devices/platform/soc/18800000.qcom,icnss/net                     u:object_r:sysfs_net:s0
 
-genfscon sysfs /devices/platform/soc/1da4000.ufshc/clkscale_enable               u:object_r:sysfs_clkscale:s0
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp/caps                  u:object_r:sysfs_mdss_mdp_caps:s0
 genfscon sysfs /devices/platform/soc/a1800000.qcom,rmtfs_rtel_sharedmem          u:object_r:sysfs_rmtfs:s0
 


### PR DESCRIPTION
The label was never used for anything and has been removed in the common sepolicy repo:
https://github.com/sonyxperiadev/device-sony-sepolicy/commit/ae81761d37c7d7023a1f998834f8a071ca22e8d1