### PR TITLE
avoid sde denials

### DIFF
--- a/sepolicy_platform/genfs_contexts
+++ b/sepolicy_platform/genfs_contexts
@@ -6,6 +6,7 @@ genfscon sysfs /devices/platform/soc/5000000.qcom,kgsl-3d0                      
 genfscon sysfs /devices/platform/soc/17300000.qcom,lpass                         u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp                       u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_rotator                   u:object_r:sysfs_msm_subsys:s0
+genfscon sysfs /devices/platform/soc/c900000.qcom,sde_rotator                    u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/4080000.qcom,mss                            u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi                           u:object_r:sysfs_msm_subsys:s0
 genfscon sysfs /devices/platform/soc/1d0101c.qcom,spss                           u:object_r:sysfs_msm_subsys:s0
@@ -26,6 +27,7 @@ genfscon sysfs /devices/platform/soc/a1800000.qcom,rmtfs_rtel_sharedmem         
 genfscon sysfs /devices/platform/soc/soc:fpc1145                                 u:object_r:sysfs_fingerprint:s0
 
 genfscon sysfs /devices/platform/soc/c900000.qcom,mdss_mdp/c900000.qcom,mdss_mdp:qcom,mdss_fb_primary/leds                     u:object_r:sysfs_leds:s0
+genfscon sysfs /devices/platform/soc/c900000.qcom,sde_kms/backlight/panel0-backlight                                           u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d000/leds    u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d300/leds    u:object_r:sysfs_leds:s0
 genfscon sysfs /devices/platform/soc/800f000.qcom,spmi/spmi-0/spmi0-03/800f000.qcom,spmi:qcom,pmi8998@3:qcom,leds@d800/leds    u:object_r:sysfs_leds:s0


### PR DESCRIPTION
01-01 02:14:39.368   625   625 I android.hardwar: type=1400 audit(0.0:5): avc: denied { read } for name=max_brightness dev=sysfs ino=41706 scontext=u:r:hal_light_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-01 02:14:39.368   625   625 I android.hardwar: type=1400 audit(0.0:6): avc: denied { open } for path=/sys/devices/platform/soc/c900000.qcom,sde_kms/backlight/panel0-backlight/max_brightness dev=sysfs ino=41706 scontext=u:r:hal_light_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-01 02:14:39.368   625   625 I android.hardwar: type=1400 audit(0.0:7): avc: denied { getattr } for path=/sys/devices/platform/soc/c900000.qcom,sde_kms/backlight/panel0-backlight/max_brightness dev=sysfs ino=41706 scontext=u:r:hal_light_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

01-01 02:14:39.579   618   618 I android.hardwar: type=1400 audit(0.0:8): avc: denied { read } for name=name dev=sysfs ino=47072 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-01 02:14:39.580   618   618 I android.hardwar: type=1400 audit(0.0:9): avc: denied { open } for path=/sys/devices/platform/soc/c900000.qcom,sde_rotator/video4linux/video0/name dev=sysfs ino=47072 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1
01-01 02:14:39.580   618   618 I android.hardwar: type=1400 audit(0.0:10): avc: denied { getattr } for path=/sys/devices/platform/soc/c900000.qcom,sde_rotator/video4linux/video0/name dev=sysfs ino=47072 scontext=u:r:hal_graphics_composer_default:s0 tcontext=u:object_r:sysfs:s0 tclass=file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>