### PR TITLE
FIX] platform.mk: Define kernel vars before common.mk

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -15,12 +15,12 @@
 # Platform path
 PLATFORM_COMMON_PATH := device/sony/yoshino
 
-$(call inherit-product, device/sony/common/common.mk)
-$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
-
 SOMC_PLATFORM := yoshino
 SOMC_KERNEL_VERSION := 4.9
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
+
+$(call inherit-product, device/sony/common/common.mk)
+$(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)
 
 SONY_ROOT := $(PLATFORM_COMMON_PATH)/rootdir
 


### PR DESCRIPTION
The `KERNEL_PATH` buildvar needs to be set before `common.mk` can be inherited.