### PR TITLE
yoshino: reduce cost of scrypt for FBE CE

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -175,6 +175,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.wifi.addr_path=/data/vendor/wifi/wlan_mac.bin
 
+# Reduce cost of scrypt for FBE CE decryption
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.crypto.scrypt_params=13:3:1
+
 # setup dm-verity configs.
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/1da4000.ufshc/by-name/system
 $(call inherit-product, build/target/product/verity.mk)


### PR DESCRIPTION
FBE CE switched from PBKDF2 to scrypt and these parameters were
considered optimal by Google. https://web.archive.org/web/20190511020438/https://blog.filippo.io/the-scrypt-parameters
gives an explanation of how the parameters work which were originally
set as ro.crypto.scrypt_params=16:3:1. It is furthermore defined in
system/vold.

Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>