### PR TITLE
yoshino: move scrypt parameters definition to common

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -179,10 +179,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.wifi.addr_path=/data/vendor/wifi/wlan_mac.bin
 
-# Reduce cost of scrypt for FBE CE decryption
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.crypto.scrypt_params=13:3:1
-
 # setup dm-verity configs.
 PRODUCT_SYSTEM_VERITY_PARTITION := /dev/block/platform/soc/1da4000.ufshc/by-name/system
 $(call inherit-product, build/target/product/verity.mk)


### PR DESCRIPTION
As discussed in the Slack group, these definitions are insecure and should have been moved to common
anyways. Burn it with fire :).

Works alongside https://github.com/sonyxperiadev/device-sony-common/pull/627.

Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>