### PR TITLE
[Android-10] Fix bdroid_buildcfg compiler errors

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -18,6 +18,12 @@
 #define _BDROID_BUILDCFG_H
 
 #if !defined(OS_GENERIC)
+#ifdef PROPERTY_VALUE_MAX
+#define PVAL_MAX_ALREADY_DEFINED
+#ifndef __CUTILS_PROPERTIES_H
+#undef PROPERTY_VALUE_MAX
+#endif
+#endif
 #include <cutils/properties.h>
 #include <string.h>
 
@@ -42,9 +48,12 @@ static inline const char* getBTDefaultName()
 }
 
 #define BTM_DEF_LOCAL_NAME getBTDefaultName()
-#endif // OS_GENERIC
 
+#ifndef PVAL_MAX_ALREADY_DEFINED
 #undef PROPERTY_VALUE_MAX
+#endif
+
+#endif // OS_GENERIC
 
 // Wide-band speech support
 #define BTM_WBS_INCLUDED TRUE


### PR DESCRIPTION
The build-system is now more strict on redefined preprocessor macros,
so we have to jump through a couple hoops to get this to pass compilation.

This file is included from many BT files:
- C or C++
- With
  - cutils/properties
  - or osi/include/properties
  defined before _or_ after our header

We should hack around this in a better way.