### PR TITLE
[YOSHINO] WCNSS: Enable concurrent STA/AP on wlan1 interface.

### DIFF
--- a/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
+++ b/rootdir/vendor/firmware/wlan/qca_cld/WCNSS_qcom_cfg.ini
@@ -197,6 +197,9 @@ gDataInactivityTimeout=200
 gSetTxChainmask1x1=1
 gSetRxChainmask1x1=1
 
+# Turn on STA + AP/STA
+gEnableConcurrentSTA=wlan1
+
 #2.4G STA/SAP-2x2, 5G STA/SAP-2x2
 gVdevTypeNss_2g=21930
 gVdevTypeNss_5g=43690


### PR DESCRIPTION
Configure WCNSS to expose a secondary interface, wlan1, which is used
for concurrent AP while wlan0 runs the STA.