### PR TITLE
[YOSHINO] PlatformConfig: Enable service locator

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -38,6 +38,7 @@ BOARD_KERNEL_TAGS_OFFSET := 0x01E00000
 BOARD_RAMDISK_OFFSET     := 0x02000000
 
 BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
+BOARD_KERNEL_CMDLINE += service_locator.enable=1
 #BOARD_KERNEL_CMDLINE += earlycon=msm_serial_dm,0xc1b0000 restore_msm_uart=0x03404000
 
 TARGET_RECOVERY_FSTAB ?= $(PLATFORM_COMMON_PATH)/rootdir/vendor/etc/fstab.yoshino


### PR DESCRIPTION
The service locator is now mandatory on kernel 4.14 because
it's needed for the FastRPC to find audio and sensors PDRs.