### PR TITLE
[2/3] platform.mk: Move KERNEL_PATH to common

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -17,7 +17,6 @@ PLATFORM_COMMON_PATH := device/sony/yoshino
 
 SOMC_PLATFORM := yoshino
 SOMC_KERNEL_VERSION := 4.14
-KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 
 $(call inherit-product, device/sony/common/common.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/core_64_bit.mk)


### PR DESCRIPTION
See https://github.com/sonyxperiadev/device-sony-common/pull/669

No need to set it in platform. Simplifies code for future refactors