### PR TITLE
ueventd: Add /vendor/firmware_mnt/image/ to firmware_directories list

### DIFF
--- a/rootdir/vendor/ueventd.rc
+++ b/rootdir/vendor/ueventd.rc
@@ -1,3 +1,5 @@
+firmware_directories /vendor/firmware_mnt/image/
+
 /dev/genlock              0666   system     system
 /dev/wlan                 0660   wifi       wifi
 /dev/kgsl-3d0             0666   system     system


### PR DESCRIPTION
For https://github.com/sonyxperiadev/device-sony-sepolicy/pull/534

In an attempt to drop the legacy and unstable /firmware symlink once and
for all, enable ueventd to read firmware directly from our own firmware
mountpoint. This much safer than relying on a (SAR) image to specify the
link for us, which is not mandatory at all and requires nasty sepolicy
hacks.

Note that the path has to end with a slash because ueventd doesn't
intersperse a "/" inbetween while searching for firmware.
