### PR TITLE
fstab: Split into early and latemount, reserve 128M on /data

### DIFF
--- a/rootdir/vendor/etc/fstab.yoshino
+++ b/rootdir/vendor/etc/fstab.yoshino
@@ -2,11 +2,11 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
-/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
-/dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,recoveryonly
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,first_stage_mount
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
+/dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab.yoshino
+++ b/rootdir/vendor/etc/fstab.yoshino
@@ -6,7 +6,7 @@
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/vendor       /vendor      ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab_legacy.yoshino
+++ b/rootdir/vendor/etc/fstab_legacy.yoshino
@@ -5,7 +5,7 @@
 /dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota,reservedsize=128M
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults

--- a/rootdir/vendor/etc/fstab_legacy.yoshino
+++ b/rootdir/vendor/etc/fstab_legacy.yoshino
@@ -2,10 +2,10 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,recoveryonly
-/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,recoveryonly
+/dev/block/bootdevice/by-name/system       /system      ext4    ro,barrier=1                                                  wait,first_stage_mount
+/dev/block/bootdevice/by-name/oem          /odm         ext4    ro,barrier=1                                                  wait,first_stage_mount
 /dev/block/bootdevice/by-name/cache        /cache       ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable
-/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic wait,check,formattable,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata     /data        ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc,errors=panic latemount,wait,check,formattable,fileencryption=ice,quota
 /dev/block/bootdevice/by-name/boot         /boot        emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/FOTAKernel   /recovery    emmc    defaults                                                      defaults
 /dev/block/bootdevice/by-name/frp          /persistent  emmc    defaults                                                      defaults


### PR DESCRIPTION
Calling @stefanhh for verification on lilac and @PaulBouchara for maple.

Makes things neater with the stage-separated mounting logic in Q and later.
