### PR TITLE
[YOSHINO] Enable audio compr_voip feature

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -202,6 +202,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Audio - QCOM HAL
 PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.feature.compr_voip.enable=true \
     vendor.audio.offload.buffer.size.kb=32
 
 # setup dm-verity configs.


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/619

This feature is required because devices in this platform do not expose
an echo-reference-voip mixer path, where -voip is concatenated when this
feature is disabled. With this feature enabled echo-reference is
selected instead, which is available and solves broken voice calls in
certain apps.
