### PR TITLE
[YOSHINO] Enable graphics allocator and mapper v3

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -79,6 +79,9 @@ NUM_FRAMEBUFFER_SURFACE_BUFFERS := 2
 DEVICE_PACKAGE_OVERLAYS += \
     $(PLATFORM_COMMON_PATH)/overlay
 
+# Graphics allocator/mapper v3
+TARGET_HARDWARE_GRAPHICS_V3 := true
+
 # Device Specific Permissions
 PRODUCT_COPY_FILES += \
      frameworks/native/data/etc/android.hardware.sensor.gyroscope.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.sensor.gyroscope.xml \


### PR DESCRIPTION
All kernel 4.14 devices were switched to graphics "v3" (rather, from 2.1 to 2.3, with 2.4 right around the corner) but Yoshino was "forgotten" or left out (iirc because k4.14 support landed later than the other platforms?). Anyway, it's here now and required to boot R where vintf version matches are more strict; vintf has always exposed `2.3` exclusively.

---

See https://github.com/sonyxperiadev/device-sony-common/pull/667

The HAL used for kernel 4.14 (8.1 branch) exports allocator and mapper v3. Setting this property makes sure the vintf manifest represents this, in turn allowing the system to use it.

