### PR TITLE
platform : Add vndservicemanager  package to fix bootloop on yoshino devices

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -183,6 +183,10 @@ PRODUCT_PACKAGES += \
    libpolyreg \
    cashsvr \
    libcashctl
+   
+# vndservicemanager
+PRODUCT_PACKAGES += 
+	vndservicemanager
 
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.qcom.bluetooth.soc=cherokee


### PR DESCRIPTION
https://github.com/sonyxperiadev/device-sony-common/blob/master/rootdir/vendor/etc/init/hw/init.common.rc#L44

init is failing to start vndservicemanager and throwing the below message :

Command 'start vndservicemanager' action=init (/system/etc/init/hw/init.rc:397) took 0ms and failed: service vndservicemanager not found
Command 'start vndservicemanager' action=init (/vendor/etc/init/hw/init.maple.rc:44) took 0ms and failed: service vndservicemanager not found

which is resulting in blank screen after the bootloader message until force shutdown.

This is fixed by adding vndservicemanager package.

Test case : Tested on maple and confirmed its booting.