### PR TITLE
init.yoshino.pwr.rc: remove deprecated configs

### DIFF
--- a/rootdir/vendor/etc/init/init.yoshino.pwr.rc
+++ b/rootdir/vendor/etc/init/init.yoshino.pwr.rc
@@ -66,7 +66,6 @@ on property:sys.boot_completed=1
     # enable governor for power cluster
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/above_hispeed_delay 19000
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate 20000
@@ -74,14 +73,11 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/io_is_busy 1
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads "83 1804800:95"
     write /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time 19000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis 79000
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu0/cpufreq/interactive/ignore_hispeed_on_notif 1
 
     # enable governor for perf cluster
     write /sys/devices/system/cpu/cpu4/online 1
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "interactive"
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/use_migration_notif 1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/above_hispeed_delay 19000
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load 90
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate 20000
@@ -89,9 +85,7 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/io_is_busy 1
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads "83 1939200:90 2016000:95"
     write /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time 19000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis 79000
     write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu4/cpufreq/interactive/ignore_hispeed_on_notif 1
 
     write /proc/sys/kernel/sched_boost 0
 


### PR DESCRIPTION
in the 4.14 kernel these configs are deprecated and should be removed to get rid of irrelevant errors in dmesg/logcat.

Applicable to yoshino,nile,ganges and tama

07-22 23:20:05.795     0     0 I init    : Command 'write /sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif 1' action=sys.boot_completed=1 (/vendor/etc/init/init.yoshino.pwr.rc:69) took 0ms and failed: Unable to write to file '/sys/devices/system/cpu/cpu0/cpufreq/interactive/use_migration_notif': open() failed: Permission denied

07-22 23:20:05.800     0     0 I init    : Command 'write /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis 79000' action=sys.boot_completed=1 (/vendor/etc/init/init.yoshino.pwr.rc:77) took 0ms and failed: Unable to write to file '/sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis': open() failed: Permission denied

07-22 23:20:05.801     0     0 I init    : Command 'write /sys/devices/system/cpu/cpu0/cpufreq/interactive/ignore_hispeed_on_notif 1' action=sys.boot_completed=1 (/vendor/etc/init/init.yoshino.pwr.rc:79) took 0ms and failed: Unable to write to file '/sys/devices/system/cpu/cpu0/cpufreq/interactive/ignore_hispeed_on_notif': open() failed: Permission denied