### PR TITLE
platform.mk: Add sscrpcd flag

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -77,6 +77,9 @@ TARGET_RECOVERY_PIXEL_FORMAT := BGRA_8888
 TARGET_USES_DRM_PP := true
 NUM_FRAMEBUFFER_SURFACE_BUFFERS := 2
 
+# Sscrpcd
+TARGET_NEEDS_SSCRPCD := true
+
 # Force building a boot image.
 # This needs to be set explicitly since Android R
 PRODUCT_BUILD_BOOT_IMAGE := true


### PR DESCRIPTION
#860 in common changes how those modules are enabled.
It adds flags thus we have to follow the changes into
device trees for platform and make sure the needed flags are
set.